### PR TITLE
Update New Zealand.json

### DIFF
--- a/English/New Zealand.json
+++ b/English/New Zealand.json
@@ -3,7 +3,7 @@
     {
       "Key": "6ae01b5d-70fd-42ab-9a4c-cd9ad76c5f71",
       "Group": "ed5a19f6-12c5-45cc-b4b7-4e79f7ef50bc",
-      "Name": "Tax payable"
+      "Name": "GST payable"
     }
   ],
   "38cf4712-6e95-4ce1-b53a-bff03edad273": [


### PR DESCRIPTION
Renaming generic "Tax payable" balance sheet account to "GST payable" account since all taxes in New Zealand are called GST.